### PR TITLE
Sliding window changes

### DIFF
--- a/pydfc/dfc_methods/discrete_hmm.py
+++ b/pydfc/dfc_methods/discrete_hmm.py
@@ -65,6 +65,7 @@ class HMM_DISC(BaseDFCMethod):
             "backend",
             "n_subj_clstrs",
             "W",
+            "window_std",
             "n_overlap",
             "n_states",
             "normalization",

--- a/pydfc/dfc_methods/sliding_window.py
+++ b/pydfc/dfc_methods/sliding_window.py
@@ -114,7 +114,8 @@ class SLIDING_WINDOW(BaseDFCMethod):
         else:
             C = np.corrcoef(time_series)
             C[np.isnan(C)] = 0
-
+            # make the diagonal elements 1 (for nan values on the diagonal)
+            C[np.diag_indices_from(C)] = 1
         return C
 
     def dFC(self, time_series, W=None, n_overlap=None, tapered_window=False, window_std=None):

--- a/pydfc/dfc_methods/sliding_window.py
+++ b/pydfc/dfc_methods/sliding_window.py
@@ -151,8 +151,7 @@ class SLIDING_WINDOW(BaseDFCMethod):
             if tapered_window:
                 std = window_std if window_std is not None else 3 * W / 22
                 window_taper = signal.windows.gaussian(W, std=std)
-                #window = signal.convolve(window, window_taper, mode="same") / sum(window_taper)
-                window[l:l+W] = window_taper
+                window = signal.convolve(window, window_taper, mode="same") / sum(window_taper)
             
             window = np.repeat(np.expand_dims(window, axis=0), time_series.shape[0], axis=0)
             FCSs.append(self.FC(np.multiply(time_series, window)[:,l:l+W]))

--- a/pydfc/dfc_methods/sliding_window.py
+++ b/pydfc/dfc_methods/sliding_window.py
@@ -106,17 +106,17 @@ class SLIDING_WINDOW(BaseDFCMethod):
             model.fit(time_series_standardized.T)
             # the covariance matrix will equal the correlation matrix
             C = model.covariance_
-       
+
         # Mutual information
         elif self.params["sw_method"] == "MI":
             C = np.zeros((time_series.shape[0], time_series.shape[0]))
-            
+
             for i in range(time_series.shape[0]):
                 for j in range(i, time_series.shape[0]):
                     X = time_series[i, :]
                     Y = time_series[j, :]
                     C[j, i] = self.calc_MI(X, Y)
-        
+
         # Pearson correlation
         else:
             C = np.corrcoef(time_series)
@@ -156,13 +156,13 @@ class SLIDING_WINDOW(BaseDFCMethod):
                 window = signal.convolve(window, window_taper, mode="same") / sum(
                     window_taper
                 )
-            
+
             window = np.repeat(
                 np.expand_dims(window, axis=0), time_series.shape[0], axis=0
             )
             FCSs.append(self.FC(np.multiply(time_series, window)[:, l : l + W]))
             TR_array.append(int((l + (l + W)) / 2))
-    
+
         return np.array(FCSs), np.array(TR_array)
 
     def estimate_FCS(self, time_series):

--- a/pydfc/dfc_methods/sliding_window.py
+++ b/pydfc/dfc_methods/sliding_window.py
@@ -97,7 +97,7 @@ class SLIDING_WINDOW(BaseDFCMethod):
 
     def FC(self, time_series):
         # Graphical Lasso
-        if self.params['sw_method']=='GraphLasso':
+        if self.params["sw_method"]=="GraphLasso":
             # Standardize the data (zero mean, unit variance for each feature)
             mean = np.mean(time_series, axis=1, keepdims=True)
             std = np.std(time_series, axis=1, keepdims=True)
@@ -108,7 +108,7 @@ class SLIDING_WINDOW(BaseDFCMethod):
             C = model.covariance_
        
         # Mutual information
-        elif self.params['sw_method']=='MI':
+        elif self.params["sw_method"]=="MI":
             C = np.zeros((time_series.shape[0], time_series.shape[0]))
             
             for i in range(time_series.shape[0]):

--- a/pydfc/dfc_methods/sliding_window.py
+++ b/pydfc/dfc_methods/sliding_window.py
@@ -97,7 +97,7 @@ class SLIDING_WINDOW(BaseDFCMethod):
 
     def FC(self, time_series):
         # Graphical Lasso
-        if self.params["sw_method"]=="GraphLasso":
+        if self.params["sw_method"] == "GraphLasso":
             # Standardize the data (zero mean, unit variance for each feature)
             mean = np.mean(time_series, axis=1, keepdims=True)
             std = np.std(time_series, axis=1, keepdims=True)
@@ -108,11 +108,11 @@ class SLIDING_WINDOW(BaseDFCMethod):
             C = model.covariance_
        
         # Mutual information
-        elif self.params["sw_method"]=="MI":
+        elif self.params["sw_method"] == "MI":
             C = np.zeros((time_series.shape[0], time_series.shape[0]))
             
             for i in range(time_series.shape[0]):
-                for j in range(i, time_series.shape[0]):      
+                for j in range(i, time_series.shape[0]):
                     X = time_series[i, :]
                     Y = time_series[j, :]
                     C[j, i] = self.calc_MI(X, Y)
@@ -125,7 +125,9 @@ class SLIDING_WINDOW(BaseDFCMethod):
             C[np.diag_indices_from(C)] = 1
         return C
 
-    def dFC(self, time_series, W=None, n_overlap=None, tapered_window=False, window_std=None):
+    def dFC(
+        self, time_series, W=None, n_overlap=None, tapered_window=False, window_std=None
+    ):
         # W is in time samples
 
         L = time_series.shape[1]
@@ -151,10 +153,14 @@ class SLIDING_WINDOW(BaseDFCMethod):
             if tapered_window:
                 std = window_std if window_std is not None else 3 * W / 22
                 window_taper = signal.windows.gaussian(W, std=std)
-                window = signal.convolve(window, window_taper, mode="same") / sum(window_taper)
+                window = signal.convolve(window, window_taper, mode="same") / sum(
+                    window_taper
+                )
             
-            window = np.repeat(np.expand_dims(window, axis=0), time_series.shape[0], axis=0)
-            FCSs.append(self.FC(np.multiply(time_series, window)[:,l:l+W]))
+            window = np.repeat(
+                np.expand_dims(window, axis=0), time_series.shape[0], axis=0
+            )
+            FCSs.append(self.FC(np.multiply(time_series, window)[:, l : l + W]))
             TR_array.append(int((l + (l + W)) / 2))
     
         return np.array(FCSs), np.array(TR_array)
@@ -186,7 +192,7 @@ class SLIDING_WINDOW(BaseDFCMethod):
             W=int(self.params["W"] * time_series.Fs),
             n_overlap=self.params["n_overlap"],
             tapered_window=self.params["tapered_window"],
-            window_std=self.params["window_std"]
+            window_std=self.params["window_std"],
         )
 
         # record time

--- a/pydfc/dfc_methods/sliding_window_clustr.py
+++ b/pydfc/dfc_methods/sliding_window_clustr.py
@@ -67,6 +67,7 @@ class SLIDING_WINDOW_CLUSTR(BaseDFCMethod):
             "coi_correction",
             "n_subj_clstrs",
             "W",
+            "window_std",
             "n_overlap",
             "n_states",
             "normalization",


### PR DESCRIPTION
Hi @mtorabi59 

I implemented the changes as discussed in #31.

The changes are:
- Removed extending the window which has two effects:
    - Bugfix regarding the zero-padding for rectangular SW calculation
    - Limits the tapered window to contain no samples outside the window width
- Added a `window_std` parameter to Sliding Window, Discrete HMM, and Sliding Window Clustering
    - Default is `None`, which results to the original std of  `3 * W / 22`
- Disabled the convolution and instead directly use the Gaussian
    - In my opinion this is unnecessary now, as the window size is a hard limit for the window
- Vectorized Pearson correlation calculation for improved performance

Feel free to modify this to your liking. Also I did not write any tests/documentation, please let me know if I should do so :)